### PR TITLE
use tags for pkgver

### DIFF
--- a/pkgver
+++ b/pkgver
@@ -1,7 +1,7 @@
 
 pkgver() {
 	cd ${srcdir}/${pkgname}
-	echo "9999.r$(git rev-list --count HEAD).c$(git rev-parse --short HEAD).${pkgrel}"
+	git describe --long --tags --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//'
 }
 
 


### PR DESCRIPTION
Use the versioning suggested in the [wiki](https://wiki.archlinux.org/title/VCS_package_guidelines#Git).

E.g., would give version numbers like `5.27.80.r10.g736fe5b`